### PR TITLE
Add event-dispatch workflow

### DIFF
--- a/.github/workflows/event-dispatch.yml
+++ b/.github/workflows/event-dispatch.yml
@@ -13,5 +13,5 @@ jobs:
         with:
           token: ${{ secrets.PAT_FIRE_EVENTS_ON_CERN_SIS_KUBERNETES }}
           repository: cern-sis/kubernetes
-          event-type: pull
+          event-type: pull-curation-event
           client-payload: '{"ref": "${{ github.sha }}"}'


### PR DESCRIPTION
This workflow dispatches a "pull" event on https://github.com/cern-sis/kubernetes repository, which will in-turn run a workflow to pull sub-tree from this repo. 